### PR TITLE
Fix for MDSPlus compile issues

### DIFF
--- a/Test/GTest/Makefile.inc
+++ b/Test/GTest/Makefile.inc
@@ -76,7 +76,7 @@ LIBRARIES   += -L$(EFDA_MARTe_DIR)/Interfaces/BaseLib2Adapter/linux -lBaseLib2Ad
 endif
 
 ifdef MDSPLUS_DIR
-LIBRARIES += -L$(MDSPLUS_DIR)/lib -lMdsObjectsCppShr
+LIBRARIES += -L$(MDSPLUS_DIR)/lib -lMdsShr -lTdiShr -lTreeShr -lMdsIpShr -lMdsObjectsCppShr
 endif
 
 ifdef EPICS_BASE


### PR DESCRIPTION
When compiling the GTest, some systems don't use relative paths for the runtime linker or MDSplus doesn't implement this - as a better way, and more sane to multiple environments - explicitly define the libraries to import in the right order.