### PR TITLE
Update SysLogger.h

### DIFF
--- a/Source/Components/Interfaces/SysLogger/SysLogger.h
+++ b/Source/Components/Interfaces/SysLogger/SysLogger.h
@@ -47,7 +47,7 @@ namespace MARTe {
  * <pre>
  * +SysLogger = {
  *     Class = SysLogger
- *     Format = ItOoFm //Compulsory. As described in LoggerConsumerI::LoadPrintPreferences
+ *     Format = EtOoFm //Compulsory. As described in LoggerConsumerI::LoadPrintPreferences
  *     PrintKeys = 1 //Optional. As described in LoggerConsumerI::LoadPrintPreferences
  *     Ident = myapp //Compulsory. Name of the syslog ident.
  * }


### PR DESCRIPTION
The SysLogger documentation implies you should use I, likely indicating Info. However if you look at MARTe2's LoggerConsumer interface you can see that it looks for E for info rather than I, so this throws an error if you try and use SysLogger as indicated in the header file unless you swap I for E.
https://github.com/sudilav/MARTe2/blob/162882ac4416431163bc8ce084ca9db9acf91223/Source/Core/Scheduler/L4LoggerService/LoggerConsumerI.cpp#L60